### PR TITLE
Fixed pretrain model not found/net_d_67500 and net_g_67500 models missing error

### DIFF
--- a/train_basicsr.yml
+++ b/train_basicsr.yml
@@ -44,7 +44,6 @@ network_d:
 path:
   pretrain_network_g: ~
   strict_load_g: true
-  resume_state: checkpoints/pretrained.state
 
 # training settings
 train:


### PR DESCRIPTION
Fixed an error where the code tried resuming from a pretrained model but couldn't because model state wasn't provided.